### PR TITLE
Add SpmSandbox example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ DerivedData/
 /Cartfile*
 /planning/
 /fester/
+
+# Example app secrets
+Example/SpmSandbox/Secrets.swift

--- a/Example/SpmSandbox.xcodeproj/project.pbxproj
+++ b/Example/SpmSandbox.xcodeproj/project.pbxproj
@@ -1,0 +1,417 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6E29840D28AA804B00D5578B /* AvoInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 6E29840C28AA804B00D5578B /* AvoInspector */; };
+		6E72BF6D2AFE85BD0008604C /* IosAnalyticsDebugger in Frameworks */ = {isa = PBXBuildFile; productRef = 6E72BF6C2AFE85BD0008604C /* IosAnalyticsDebugger */; };
+		6E7E509E27612F7900CAFB96 /* SpmSandboxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E509D27612F7900CAFB96 /* SpmSandboxApp.swift */; };
+		6E7E50A027612F7900CAFB96 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E509F27612F7900CAFB96 /* ContentView.swift */; };
+		6E7E50A227612F7A00CAFB96 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E7E50A127612F7A00CAFB96 /* Assets.xcassets */; };
+		6E7E50A527612F7A00CAFB96 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E7E50A427612F7A00CAFB96 /* Preview Assets.xcassets */; };
+		6E895B4D2DDF7B420043E83A /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E895B4B2DDF7B400043E83A /* Secrets.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6E154C25276908E90004935D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		6E7E509A27612F7900CAFB96 /* SpmSandbox.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpmSandbox.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6E7E509D27612F7900CAFB96 /* SpmSandboxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpmSandboxApp.swift; sourceTree = "<group>"; };
+		6E7E509F27612F7900CAFB96 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		6E7E50A127612F7A00CAFB96 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6E7E50A427612F7A00CAFB96 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		6E895B4B2DDF7B400043E83A /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
+		6E895B4C2DDF7B410043E83A /* Secrets.example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.example.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6E7E509727612F7900CAFB96 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6E72BF6D2AFE85BD0008604C /* IosAnalyticsDebugger in Frameworks */,
+				6E29840D28AA804B00D5578B /* AvoInspector in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6E14AEA0276A0A9D0030AF9A /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		6E154C262769095D0004935D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6E7E509127612F7900CAFB96 = {
+			isa = PBXGroup;
+			children = (
+				6E14AEA0276A0A9D0030AF9A /* Packages */,
+				6E7E509C27612F7900CAFB96 /* SpmSandbox */,
+				6E7E509B27612F7900CAFB96 /* Products */,
+				6E154C262769095D0004935D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		6E7E509B27612F7900CAFB96 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6E7E509A27612F7900CAFB96 /* SpmSandbox.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6E7E509C27612F7900CAFB96 /* SpmSandbox */ = {
+			isa = PBXGroup;
+			children = (
+				6E895B4B2DDF7B400043E83A /* Secrets.swift */,
+				6E895B4C2DDF7B410043E83A /* Secrets.example.swift */,
+				6E154C25276908E90004935D /* Info.plist */,
+				6E7E509D27612F7900CAFB96 /* SpmSandboxApp.swift */,
+				6E7E509F27612F7900CAFB96 /* ContentView.swift */,
+				6E7E50A127612F7A00CAFB96 /* Assets.xcassets */,
+				6E7E50A327612F7A00CAFB96 /* Preview Content */,
+			);
+			path = SpmSandbox;
+			sourceTree = "<group>";
+		};
+		6E7E50A327612F7A00CAFB96 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				6E7E50A427612F7A00CAFB96 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6E7E509927612F7900CAFB96 /* SpmSandbox */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6E7E50A827612F7A00CAFB96 /* Build configuration list for PBXNativeTarget "SpmSandbox" */;
+			buildPhases = (
+				6E7E509627612F7900CAFB96 /* Sources */,
+				6E7E509727612F7900CAFB96 /* Frameworks */,
+				6E7E509827612F7900CAFB96 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SpmSandbox;
+			packageProductDependencies = (
+				6E29840C28AA804B00D5578B /* AvoInspector */,
+				6E72BF6C2AFE85BD0008604C /* IosAnalyticsDebugger */,
+			);
+			productName = SpmSandbox;
+			productReference = 6E7E509A27612F7900CAFB96 /* SpmSandbox.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6E7E509227612F7900CAFB96 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1310;
+				LastUpgradeCheck = 1310;
+				TargetAttributes = {
+					6E7E509927612F7900CAFB96 = {
+						CreatedOnToolsVersion = 13.1;
+					};
+				};
+			};
+			buildConfigurationList = 6E7E509527612F7900CAFB96 /* Build configuration list for PBXProject "SpmSandbox" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6E7E509127612F7900CAFB96;
+			packageReferences = (
+				6E29840B28AA804B00D5578B /* XCLocalSwiftPackageReference "AvoInspectorSPM" */,
+				6E72BF6B2AFE85BD0008604C /* XCRemoteSwiftPackageReference "ios-analytics-debugger-spm" */,
+			);
+			productRefGroup = 6E7E509B27612F7900CAFB96 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6E7E509927612F7900CAFB96 /* SpmSandbox */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6E7E509827612F7900CAFB96 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6E7E50A527612F7A00CAFB96 /* Preview Assets.xcassets in Resources */,
+				6E7E50A227612F7A00CAFB96 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6E7E509627612F7900CAFB96 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6E7E50A027612F7900CAFB96 /* ContentView.swift in Sources */,
+				6E7E509E27612F7900CAFB96 /* SpmSandboxApp.swift in Sources */,
+				6E895B4D2DDF7B420043E83A /* Secrets.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6E7E50A627612F7A00CAFB96 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		6E7E50A727612F7A00CAFB96 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6E7E50A927612F7A00CAFB96 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SpmSandbox/Preview Content\"";
+				DEVELOPMENT_TEAM = G7H6Q48U3Z;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SpmSandbox/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.1;
+				PRODUCT_BUNDLE_IDENTIFIER = app.avo.SpmSandbox;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6E7E50AA27612F7A00CAFB96 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SpmSandbox/Preview Content\"";
+				DEVELOPMENT_TEAM = G7H6Q48U3Z;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SpmSandbox/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.1;
+				PRODUCT_BUNDLE_IDENTIFIER = app.avo.SpmSandbox;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6E7E509527612F7900CAFB96 /* Build configuration list for PBXProject "SpmSandbox" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6E7E50A627612F7A00CAFB96 /* Debug */,
+				6E7E50A727612F7A00CAFB96 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6E7E50A827612F7A00CAFB96 /* Build configuration list for PBXNativeTarget "SpmSandbox" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6E7E50A927612F7A00CAFB96 /* Debug */,
+				6E7E50AA27612F7A00CAFB96 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		6E29840B28AA804B00D5578B /* XCLocalSwiftPackageReference "AvoInspectorSPM" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6E72BF6B2AFE85BD0008604C /* XCRemoteSwiftPackageReference "ios-analytics-debugger-spm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/avohq/ios-analytics-debugger-spm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6E29840C28AA804B00D5578B /* AvoInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6E29840B28AA804B00D5578B /* XCLocalSwiftPackageReference "AvoInspectorSPM" */;
+			productName = AvoInspector;
+		};
+		6E72BF6C2AFE85BD0008604C /* IosAnalyticsDebugger */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6E72BF6B2AFE85BD0008604C /* XCRemoteSwiftPackageReference "ios-analytics-debugger-spm" */;
+			productName = IosAnalyticsDebugger;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 6E7E509227612F7900CAFB96 /* Project object */;
+}

--- a/Example/SpmSandbox.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/SpmSandbox.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/SpmSandbox.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/SpmSandbox.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/SpmSandbox.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/SpmSandbox.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Example/SpmSandbox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SpmSandbox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "4bee0fdb363d90efe95d467ab0b42aa95225a7e0336bbf96d448a7733f9a7601",
+  "pins" : [
+    {
+      "identity" : "ios-analytics-debugger-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/avohq/ios-analytics-debugger-spm",
+      "state" : {
+        "revision" : "d5c134c54052733afe425b357b47ec080484ed88",
+        "version" : "1.5.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Example/SpmSandbox/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/SpmSandbox/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/SpmSandbox/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/SpmSandbox/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/SpmSandbox/Assets.xcassets/Contents.json
+++ b/Example/SpmSandbox/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/SpmSandbox/ContentView.swift
+++ b/Example/SpmSandbox/ContentView.swift
@@ -1,0 +1,397 @@
+//
+//  ContentView.swift
+//  SpmSandbox
+//
+//  Created by Alex Verein on 08.12.2021.
+//
+
+import SwiftUI
+import AvoInspector
+import IosAnalyticsDebugger
+
+struct ContentView: View {
+
+    @State private var log: [String] = []
+    @State private var inspector: AvoInspector?
+    let debugger = AnalyticsDebugger()
+
+    var body: some View {
+        NavigationView {
+            List {
+                // MARK: - Init
+                Section("Initialization") {
+                    Button("Init (basic)") {
+                        inspector = AvoInspector(apiKey: Secrets.apiKey, env: .dev)
+                        debugger.showBubble()
+                        append("Init basic — OK, lib \(inspector!.libVersion)")
+                    }
+                    Button("Init (with encryption key)") {
+                        inspector = AvoInspector(
+                            apiKey: Secrets.apiKey, env: .dev,
+                            publicEncryptionKey: Secrets.publicEncryptionKey)
+                        debugger.showBubble()
+                        append("Init encrypted — OK")
+                    }
+                    Button("Init (with proxy endpoint)") {
+                        inspector = AvoInspector(
+                            apiKey: Secrets.apiKey, env: .dev,
+                            proxyEndpoint: "https://api.avo.app/inspector/v1/track")
+                        append("Init proxy — OK")
+                    }
+                    Button("Init (prod env)") {
+                        inspector = AvoInspector(apiKey: Secrets.apiKey, env: .prod)
+                        append("Init prod — OK, logging=\(AvoInspector.isLogging())")
+                    }
+                    Button("Init (staging env)") {
+                        inspector = AvoInspector(apiKey: Secrets.apiKey, env: .staging)
+                        append("Init staging — OK")
+                    }
+                }
+
+                // MARK: - Logging & Config
+                Section("Logging & Config") {
+                    Button("Toggle logging") {
+                        let current = AvoInspector.isLogging()
+                        AvoInspector.setLogging(!current)
+                        append("Logging: \(!current)")
+                    }
+                    Button("Set batch size = 5") {
+                        AvoInspector.setBatchSize(5)
+                        append("Batch size: \(AvoInspector.getBatchSize())")
+                    }
+                    Button("Set flush interval = 10s") {
+                        AvoInspector.setBatchFlushSeconds(10)
+                        append("Flush seconds: \(AvoInspector.getBatchFlushSeconds())")
+                    }
+                }
+
+                // MARK: - Schema Tracking
+                Section("Schema Tracking") {
+                    Button("trackSchema (simple)") {
+                        guard let inspector else { return append("Init first!") }
+                        let name = "Account Created"
+                        let params: [String: Any] = [
+                            "email": "test@avo.app",
+                            "age": 28,
+                            "verified": true
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Tracked — \(formatSchema(schema))")
+                    }
+                    Button("trackSchema (complex params)") {
+                        guard let inspector else { return append("Init first!") }
+                        let name = "Purchase Completed"
+                        let params: [String: Any] = [
+                            "item": "Widget",
+                            "price": 9.99,
+                            "quantity": 2,
+                            "tags": ["sale", "new"],
+                            "address": ["city": "Oslo", "zip": 1234],
+                            "nothing": NSNull()
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Tracked complex — \(formatSchema(schema))")
+                    }
+                    Button("trackSchema (manual schema)") {
+                        guard let inspector else { return append("Init first!") }
+                        let name = "Manual Event"
+                        let params: [String: Any] = [
+                            "name": "test",
+                            "count": 1,
+                            "active": true
+                        ]
+                        inspector.trackSchema(name, eventSchema: [
+                            "name": AvoString(),
+                            "count": AvoInt(),
+                            "active": AvoBoolean()
+                        ])
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Tracked manual schema — OK")
+                    }
+                }
+
+                // MARK: - Schema Extraction
+                Section("Schema Extraction") {
+                    Button("Extract all types") {
+                        guard let inspector else { return append("Init first!") }
+                        let schema = inspector.extractSchema([
+                            "str": "hello",
+                            "int": 42,
+                            "float": 3.14,
+                            "bool": true,
+                            "null": NSNull(),
+                            "list": [1, "two", 3.0],
+                            "obj": ["nested": "value"]
+                        ])
+                        append("Extracted — \(formatSchema(schema))")
+                    }
+                    Button("Extract empty dict") {
+                        guard let inspector else { return append("Init first!") }
+                        let schema = inspector.extractSchema([:])
+                        append("Empty — \(schema.count) keys")
+                    }
+                }
+
+                // MARK: - Deduplication
+                Section("Deduplication") {
+                    Button("Track same event twice (fast)") {
+                        guard let inspector else { return append("Init first!") }
+                        let params: [String: Any] = ["key": "dedup_test"]
+                        let r1 = inspector.trackSchema(fromEvent: "Dedup Test", eventParams: params)
+                        let r2 = inspector.trackSchema(fromEvent: "Dedup Test", eventParams: params)
+                        let firstTracked = !r1.isEmpty
+                        let secondDeduped = r2.isEmpty
+                        append("1st tracked=\(firstTracked), 2nd deduped=\(secondDeduped)")
+                    }
+                    Button("Track same event twice (after delay)") {
+                        guard let inspector else { return append("Init first!") }
+                        let params: [String: Any] = ["key": "delay_test"]
+                        let r1 = inspector.trackSchema(fromEvent: "Delay Test", eventParams: params)
+                        append("1st tracked=\(!r1.isEmpty), waiting 0.5s...")
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            let r2 = inspector.trackSchema(fromEvent: "Delay Test", eventParams: params)
+                            append("2nd tracked=\(!r2.isEmpty) (should be true after 300ms)")
+                        }
+                    }
+                }
+
+                // MARK: - Lifecycle
+                Section("Lifecycle") {
+                    Button("enterBackground()") {
+                        guard let inspector else { return append("Init first!") }
+                        inspector.enterBackground()
+                        append("enterBackground — OK")
+                    }
+                    Button("enterForeground()") {
+                        guard let inspector else { return append("Init first!") }
+                        inspector.enterForeground()
+                        append("enterForeground — OK")
+                    }
+                }
+
+                // MARK: - Edge Cases
+                Section("Edge Cases") {
+                    Button("Empty event name") {
+                        guard let inspector else { return append("Init first!") }
+                        let schema = inspector.trackSchema(fromEvent: "", eventParams: ["a": 1])
+                        append("Empty name — \(schema.isEmpty ? "empty" : "ok"), no crash")
+                    }
+                    Button("Large params (100 keys)") {
+                        guard let inspector else { return append("Init first!") }
+                        var params = [String: Any]()
+                        for i in 0..<100 { params["key_\(i)"] = i }
+                        let schema = inspector.trackSchema(fromEvent: "Big Event", eventParams: params)
+                        append("100 keys — \(schema.count) types extracted, no crash")
+                    }
+                    Button("Deeply nested object") {
+                        guard let inspector else { return append("Init first!") }
+                        let schema = inspector.trackSchema(
+                            fromEvent: "Deep Event",
+                            eventParams: [
+                                "l1": ["l2": ["l3": ["l4": "deep"]]]
+                            ])
+                        append("Nested — \(formatSchema(schema)), no crash")
+                    }
+                    Button("Multi-thread stress test") {
+                        guard let inspector else { return append("Init first!") }
+                        let group = DispatchGroup()
+                        for i in 0..<20 {
+                            group.enter()
+                            DispatchQueue.global().async {
+                                _ = inspector.trackSchema(
+                                    fromEvent: "Thread \(i)",
+                                    eventParams: ["thread": i])
+                                group.leave()
+                            }
+                        }
+                        group.notify(queue: .main) {
+                            append("20 concurrent calls — no crash")
+                        }
+                    }
+                }
+
+                // MARK: - Validation & Encryption (Form Field Activated)
+                Section("Validation & Encryption") {
+                    Button("Init with encryption") {
+                        inspector = AvoInspector(
+                            apiKey: Secrets.apiKey, env: .dev,
+                            publicEncryptionKey: Secrets.publicEncryptionKey)
+                        debugger.showBubble()
+                        append("Init with encryption — OK")
+                    }
+                    Button("Valid event (all allowed values)") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let name = "Form Field Activated"
+                        let params: [String: Any] = [
+                            "Form Field": "First Name",
+                            "Form Purpose": "Webinar",
+                            "Path": "docs/quickstart",
+                            "Client": "Web",
+                            "Version": "1.0.0",
+                            "UTM Source": "google",
+                            "UTM Medium": "cpc",
+                            "UTM Campaign": "spring",
+                            "UTM Term": "analytics",
+                            "UTM Content": "banner"
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Valid — \(formatSchema(schema))")
+                    }
+                    Button("Invalid Form Field (bad allowed value)") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let name = "Form Field Activated"
+                        let params: [String: Any] = [
+                            "Form Field": "Phone Number",
+                            "Form Purpose": "Demo",
+                            "Path": "docs/quickstart",
+                            "Client": "Web",
+                            "Version": "1.0.0",
+                            "UTM Source": "google",
+                            "UTM Medium": "cpc",
+                            "UTM Campaign": "spring",
+                            "UTM Term": "analytics",
+                            "UTM Content": "banner"
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Invalid Form Field — \(formatSchema(schema))")
+                    }
+                    Button("Invalid Form Purpose (bad allowed value)") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let name = "Form Field Activated"
+                        let params: [String: Any] = [
+                            "Form Field": "Email",
+                            "Form Purpose": "Contest",
+                            "Path": "docs/quickstart",
+                            "Client": "Landing Page",
+                            "Version": "2.0.0",
+                            "UTM Source": "bing",
+                            "UTM Medium": "organic",
+                            "UTM Campaign": "fall",
+                            "UTM Term": "tracking",
+                            "UTM Content": "sidebar"
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Invalid Purpose — \(formatSchema(schema))")
+                    }
+                    Button("Wrong type (int instead of string)") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let name = "Form Field Activated"
+                        let params: [String: Any] = [
+                            "Form Field": 42,
+                            "Form Purpose": "Raffle",
+                            "Path": true,
+                            "Client": "Cli",
+                            "Version": "1.0.0"
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Wrong types — \(formatSchema(schema))")
+                    }
+                    Button("Missing required props") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let name = "Form Field Activated"
+                        let params: [String: Any] = [
+                            "Form Field": "Last Name"
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Missing props — \(formatSchema(schema))")
+                    }
+                    Button("Extra unexpected prop") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let name = "Form Field Activated"
+                        let params: [String: Any] = [
+                            "Form Field": "Company",
+                            "Form Purpose": "Demo",
+                            "Path": "signup",
+                            "Client": "Web",
+                            "Version": "1.0.0",
+                            "Unexpected Extra Prop": "surprise"
+                        ]
+                        let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                        debugger.debugEvent(name, eventParams: params)
+                        append("Extra prop — \(formatSchema(schema))")
+                    }
+                    Button("All allowed Form Field values") {
+                        guard let inspector else { return append("Init with encryption first!") }
+                        let allowedFields = ["First Name", "Last Name", "Email", "Company", "Job Title"]
+                        for field in allowedFields {
+                            let name = "Form Field Activated"
+                            let params: [String: Any] = [
+                                "Form Field": field,
+                                "Form Purpose": "Webinar",
+                                "Path": "docs/test",
+                                "Client": "Web",
+                                "Version": "1.0.0"
+                            ]
+                            let schema = inspector.trackSchema(fromEvent: name, eventParams: params)
+                            debugger.debugEvent(name, eventParams: params)
+                            append("\(field) — \(schema.isEmpty ? "deduped" : "ok")")
+                        }
+                    }
+                }
+
+                // MARK: - Debugger
+                Section("Visual Debugger") {
+                    Button("Show debugger bubble") {
+                        debugger.showBubble()
+                        append("Debugger bubble shown")
+                    }
+                    Button("Send event to debugger") {
+                        debugger.debugEvent("Test Event", eventParams: ["key": "value"])
+                        append("Debugger event sent")
+                    }
+                }
+
+                // MARK: - Properties
+                Section("Inspector Properties") {
+                    Button("Print properties") {
+                        guard let inspector else { return append("Init first!") }
+                        append("apiKey=\(inspector.apiKey)")
+                        append("appVersion=\(inspector.appVersion)")
+                        append("libVersion=\(inspector.libVersion)")
+                    }
+                    Button("Anonymous ID") {
+                        let id = AvoAnonymousId.anonymousId()
+                        append("anonId=\(id)")
+                    }
+                }
+
+                // MARK: - Log Output
+                Section("Log") {
+                    if log.isEmpty {
+                        Text("Tap a test above").foregroundColor(.secondary)
+                    }
+                    ForEach(Array(log.enumerated().reversed()), id: \.offset) { _, entry in
+                        Text(entry).font(.caption).lineLimit(3)
+                    }
+                    if !log.isEmpty {
+                        Button("Clear log", role: .destructive) { log.removeAll() }
+                    }
+                }
+            }
+            .navigationTitle("AvoInspector QA")
+        }
+    }
+
+    private func append(_ msg: String) {
+        log.append(msg)
+    }
+
+    private func formatSchema(_ schema: [String: AvoEventSchemaType]) -> String {
+        schema.map { "\($0.key):\($0.value.name())" }
+            .sorted()
+            .joined(separator: ", ")
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Example/SpmSandbox/Info.plist
+++ b/Example/SpmSandbox/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Example/SpmSandbox/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Example/SpmSandbox/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/SpmSandbox/Secrets.example.swift
+++ b/Example/SpmSandbox/Secrets.example.swift
@@ -1,0 +1,7 @@
+// Copy this file to Secrets.swift and fill in your keys.
+// Secrets.swift is gitignored and will not be committed.
+
+enum Secrets {
+    static let apiKey = "<YOUR_AVO_API_KEY>"
+    static let publicEncryptionKey = "<YOUR_PUBLIC_ENCRYPTION_KEY>"
+}

--- a/Example/SpmSandbox/SpmSandboxApp.swift
+++ b/Example/SpmSandbox/SpmSandboxApp.swift
@@ -1,0 +1,17 @@
+//
+//  SpmSandboxApp.swift
+//  SpmSandbox
+//
+//  Created by Alex Verein on 08.12.2021.
+//
+
+import SwiftUI
+
+@main
+struct SpmSandboxApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the SpmSandbox QA testing app under `Example/` directory
- Extracts hardcoded API key and encryption key into a gitignored `Secrets.swift` with a committed `Secrets.example.swift` template
- Updates the Xcode project's local SPM package reference to point at the repo root (`..`) so it resolves correctly from `Example/`

## Setup
Copy `Example/SpmSandbox/Secrets.example.swift` to `Example/SpmSandbox/Secrets.swift` and fill in your Avo API key and public encryption key.

## Test plan
- [ ] Open `Example/SpmSandbox.xcodeproj` in Xcode
- [ ] Verify AvoInspector resolves as a local SPM package from the repo root
- [ ] Build and run the app on a simulator
- [ ] Confirm `Secrets.swift` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example iOS app (SpmSandbox) demonstrating Swift Package Manager integration and testing functionality for analytics instrumentation.

* **Chores**
  * Updated .gitignore to exclude app secrets configuration.
  * Added project configuration, asset catalogs, and example secrets template for the new example app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->